### PR TITLE
Task/1210069039785318/encripted fields confirmation/ifarankhan/main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added checkbox in `Options\Fields\EncrypytedPasswordField` field to confirm if user want to update the value.
+
 ## [1.13.0] - 2025-03-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
 - Added Remove button in `Options\Fields\EncrypytedPasswordField` field to change value only if user want to update the value.
 
 ## [1.13.0] - 2025-03-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Added checkbox in `Options\Fields\EncrypytedPasswordField` field to confirm if user want to update the value.
+- Added Remove button in `Options\Fields\EncrypytedPasswordField` field to change value only if user want to update the value.
 
 ## [1.13.0] - 2025-03-04
 

--- a/inc/Options/Fields/EncrypytedPasswordField.php
+++ b/inc/Options/Fields/EncrypytedPasswordField.php
@@ -55,6 +55,7 @@ class EncrypytedPasswordField extends PasswordField {
 	public function before_save(mixed $new_value, mixed $old_value): mixed {
 
         // if old value is empty or user agreed to update the value.
+		// phpcs:ignore: WordPress.Security.NonceVerification.Recommended
         if ( empty( $old_value ) || isset( $_REQUEST[ $this->field_id . '_acceptance' ] ) ) {
             return $this->encrypt($new_value);
         }

--- a/inc/Options/Fields/EncrypytedPasswordField.php
+++ b/inc/Options/Fields/EncrypytedPasswordField.php
@@ -8,17 +8,7 @@ class EncrypytedPasswordField extends PasswordField {
 	protected string $field_id = '';
 
 	public function __construct( string $id, string $title, array $args = [], $encryption_key = null ) {
-		parent::__construct(
-			$id,
-			$title,
-			array_merge(
-				[
-					'notice' => __( 'Value is not shown in the input after loading. Re-insert value before saving page.', 'airfleet' ),
-					'notice_type' => 'warning',
-				],
-				$args
-			)
-		);
+		parent::__construct( $id, $title, $args );
 		$this->field_id = $id;
 		$fallback_encryption_key = '|EZi7!^(oRQ^?r|/W-X^S5jS]M,zaDw+G%zYb$9!8gN{u(i}4llyWK-9afD|Y|3W';
 		$this->encryption_key = $encryption_key ? $encryption_key : ( defined( 'SECURE_AUTH_KEY' ) ? \SECURE_AUTH_KEY : $fallback_encryption_key );
@@ -81,7 +71,7 @@ class EncrypytedPasswordField extends PasswordField {
         // Show checkbox if field have old value.
         if ( ! empty( $value ) ) {
             printf('<input type="hidden" name="%1$s_change" id="%1$s_change" value="0">', $this->field_id);
-            printf('<input type="button" class="button button-secondry" value="Remove Value" onclick="let fieldInput = document.getElementById(\'%1$s\'); fieldInput.removeAttribute(\'disabled\'); fieldInput.removeAttribute(\'placeholder\'); document.getElementById(\'%1$s_change\').value=\'1\';">', $this->field_id);
+            printf('<input type="button" class="button button-secondry" style="margin-left: 5px;" value="Remove Value" onclick="let fieldInput = document.getElementById(\'%1$s\'); fieldInput.removeAttribute(\'disabled\'); fieldInput.removeAttribute(\'placeholder\'); document.getElementById(\'%1$s_change\').value=\'1\';">', $this->field_id);
         }
     }
 }

--- a/inc/Options/Fields/EncrypytedPasswordField.php
+++ b/inc/Options/Fields/EncrypytedPasswordField.php
@@ -54,9 +54,9 @@ class EncrypytedPasswordField extends PasswordField {
 
 	public function before_save(mixed $new_value, mixed $old_value): mixed {
 
-        // if old value is empty or user agreed to update the value.
+        // if old value is empty or user wanted to change value.
 		// phpcs:ignore: WordPress.Security.NonceVerification.Recommended
-        if ( empty( $old_value ) || isset( $_REQUEST[ $this->field_id . '_acceptance' ] ) ) {
+        if ( empty( $old_value ) || ( isset( $_REQUEST[ $this->field_id . '_change' ] ) && '1' === $_REQUEST[ $this->field_id . '_change' ] ) ) {
             return $this->encrypt($new_value);
         }
 
@@ -72,6 +72,7 @@ class EncrypytedPasswordField extends PasswordField {
         // pust some asterisk in placeholder showcase old value.
         if ( ! empty($value) ) {
             $args['placeholder'] = '******************';
+            $args['disabled'] = 'disabled';
         }
 
         // ! Do not show value when editing field
@@ -79,7 +80,8 @@ class EncrypytedPasswordField extends PasswordField {
 
         // Show checkbox if field have old value.
         if ( ! empty( $value ) ) {
-            \printf('<br><br><label for="%1$s_acceptance"><input type="checkbox" name="%1$s_acceptance" id="%1$s_acceptance" class="regular-text" value="1">By Checking this I agree to update the field value.</label>', $this->field_id);
+            printf('<input type="hidden" name="%1$s_change" id="%1$s_change" value="0">', $this->field_id);
+            printf('<input type="button" class="button button-secondry" value="Remove Value" onclick="let fieldInput = document.getElementById(\'%1$s\'); fieldInput.removeAttribute(\'disabled\'); fieldInput.removeAttribute(\'placeholder\'); document.getElementById(\'%1$s_change\').value=\'1\';">', $this->field_id);
         }
     }
 }

--- a/inc/Options/Fields/EncrypytedPasswordField.php
+++ b/inc/Options/Fields/EncrypytedPasswordField.php
@@ -69,7 +69,7 @@ class EncrypytedPasswordField extends PasswordField {
 
 	// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
     protected function render_input(array $args, mixed $value): void {
-        // pust some asterisk in placeholder showcase old value.
+        // puts some asterisk in placeholder showcase old value.
         if ( ! empty($value) ) {
             $args['placeholder'] = '******************';
             $args['disabled'] = 'disabled';

--- a/inc/Options/Fields/Field.php
+++ b/inc/Options/Fields/Field.php
@@ -124,9 +124,9 @@ abstract class Field {
 		return $this->call_args_callback( 'sanitize', $value, [ $this, 'default_sanitize' ] );
 	}
 
-	public function before_save( mixed $value ): mixed {
-		return $value;
-	}
+	public function before_save(mixed $new_value, mixed $old_value): mixed {
+        return $new_value;
+    }
 
 	public function validate( mixed $value ): bool {
 		return $this->call_args_callback( 'validate', $value, [ $this, 'default_validate' ] );

--- a/inc/Options/Group.php
+++ b/inc/Options/Group.php
@@ -71,7 +71,7 @@ class Group {
 			$field = $this->field( $id );
 			$old_value = $this->value( $id );
 			$new_value = $field->sanitize( $value );
-			$save_value = $field->validate( $new_value ) ? $field->before_save( $new_value ) : $old_value;
+			$save_value = $field->validate( $new_value ) ? $field->before_save($new_value, $old_value) : $old_value;
 			$result[ $id ] = $save_value;
 		}
 
@@ -80,7 +80,7 @@ class Group {
 				$id = $field->id();
 				$old_value = $this->value( $id );
 				$new_value = $field->sanitize( $values[ $id ] ?? null );
-				$save_value = $field->validate( $new_value ) ? $field->before_save( $new_value ) : $old_value;
+				$save_value = $field->validate( $new_value ) ? $field->before_save($new_value, $old_value) : $old_value;
 				$result[ $id ] = $save_value;
 			}
 		}


### PR DESCRIPTION
# Description


# Asana task
Asana link: 

# Checklist
- [ ] Verified there are no merge conflicts
- [ ] Verified the pipeline passed
- [ ] Updated documentation on Notion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a button to encrypted password fields allowing users to remove the saved value and enable editing.
  - Password fields display a placeholder of asterisks and disable direct editing when a value exists.
- **Bug Fixes**
  - Improved password update logic to encrypt only when confirmed or if no previous value exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210069039785318